### PR TITLE
enhancement - add response header code on error handling default fiber rest

### DIFF
--- a/fiber-rest/middleware.go
+++ b/fiber-rest/middleware.go
@@ -46,7 +46,7 @@ func JaegerTracingMiddleware(c *fiber.Ctx) error {
 	}
 
 	trace.SetTag("http.engine", "fiber (fasthttp) version "+fiber.Version)
-	trace.SetTag("http.method", c.Method())
+	trace.SetTag("http.method", r.Method)
 	trace.SetTag("http.url_path", c.Path())
 	for key := range c.GetReqHeaders() {
 		trace.SetTag("http.headers."+key, c.Get(key))

--- a/fiber-rest/option.go
+++ b/fiber-rest/option.go
@@ -36,7 +36,7 @@ func defaultErrHandler(ctx *fiber.Ctx, err error) error {
 	if errors.As(err, &e) {
 		code = e.Code
 	}
-	return ctx.JSON(wrapper.HTTPResponse{
+	return ctx.Status(code).JSON(wrapper.HTTPResponse{
 		Code: code, Success: false, Message: err.Error(),
 	})
 }


### PR DESCRIPTION

<img width="1008" alt="Screenshot 2025-01-14 at 14 45 52" src="https://github.com/user-attachments/assets/62b95133-28d4-46d1-8d98-69998f925de7" />

solve when fiber.Error return also the status response not only on json response

